### PR TITLE
build: allow floating version #

### DIFF
--- a/contracts/interfaces/IGasliteDrop.sol
+++ b/contracts/interfaces/IGasliteDrop.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ *                                                           bbbbbbbb                                         dddddddd
+ *                                                           b::::::b                                         d::::::d
+ *                                                           b::::::b                                         d::::::d
+ *                                                           b::::::b                                         d::::::d
+ *                                                            b:::::b                                         d:::::d
+ *    ggggggggg   ggggg aaaaaaaaaaaaa      ssssssssss         b:::::bbbbbbbbb      aaaaaaaaaaaaa      ddddddddd:::::d
+ *   g:::::::::ggg::::g a::::::::::::a   ss::::::::::s        b::::::::::::::bb    a::::::::::::a   dd::::::::::::::d
+ *  g:::::::::::::::::g aaaaaaaaa:::::ass:::::::::::::s       b::::::::::::::::b   aaaaaaaaa:::::a d::::::::::::::::d
+ * g::::::ggggg::::::gg          a::::as::::::ssss:::::s      b:::::bbbbb:::::::b           a::::ad:::::::ddddd:::::d
+ * g:::::g     g:::::g    aaaaaaa:::::a s:::::s  ssssss       b:::::b    b::::::b    aaaaaaa:::::ad::::::d    d:::::d
+ * g:::::g     g:::::g  aa::::::::::::a   s::::::s            b:::::b     b:::::b  aa::::::::::::ad:::::d     d:::::d
+ * g:::::g     g:::::g a::::aaaa::::::a      s::::::s         b:::::b     b:::::b a::::aaaa::::::ad:::::d     d:::::d
+ * g::::::g    g:::::ga::::a    a:::::assssss   s:::::s       b:::::b     b:::::ba::::a    a:::::ad:::::d     d:::::d
+ * g:::::::ggggg:::::ga::::a    a:::::as:::::ssss::::::s      b:::::bbbbbb::::::ba::::a    a:::::ad::::::ddddd::::::dd
+ *  g::::::::::::::::ga:::::aaaa::::::as::::::::::::::s       b::::::::::::::::b a:::::aaaa::::::a d:::::::::::::::::d
+ *   gg::::::::::::::g a::::::::::aa:::as:::::::::::ss        b:::::::::::::::b   a::::::::::aa:::a d:::::::::ddd::::d
+ *     gggggggg::::::g  aaaaaaaaaa  aaaa sssssssssss          bbbbbbbbbbbbbbbb     aaaaaaaaaa  aaaa  ddddddddd   ddddd
+ *             g:::::g
+ * gggggg      g:::::g
+ * g:::::gg   gg:::::g
+ *  g::::::ggg:::::::g
+ *   gg:::::::::::::g
+ *     ggg::::::ggg
+ *        gggggg
+ */
+
+/**
+ * @title GasliteDrop
+ * @notice Turbo gas optimized bulk transfers of ERC20, ERC721, and ETH
+ * @author Harrison (@PopPunkOnChain)
+ * @author Gaslite (@GasliteGG)
+ * @author Pop Punk LLC (@PopPunkLLC)
+ */
+interface IGasliteDrop {
+    /**
+     * @notice Airdrop ERC721 tokens to a list of addresses
+     * @param _nft The address of the ERC721 contract
+     * @param _addresses The addresses to airdrop to
+     * @param _tokenIds The tokenIds to airdrop
+     */
+    function airdropERC721(address _nft, address[] calldata _addresses, uint256[] calldata _tokenIds)
+        external
+        payable;
+
+    /**
+     * @notice Airdrop ERC20 tokens to a list of addresses
+     * @param _token The address of the ERC20 contract
+     * @param _addresses The addresses to airdrop to
+     * @param _amounts The amounts to airdrop
+     * @param _totalAmount The total amount to airdrop
+     */
+    function airdropERC20(
+        address _token,
+        address[] calldata _addresses,
+        uint256[] calldata _amounts,
+        uint256 _totalAmount
+    ) external payable;
+
+    /**
+     * @notice Airdrop ETH to a list of addresses
+     * @param _addresses The addresses to airdrop to
+     * @param _amounts The amounts to airdrop
+     */
+    function airdropETH(address[] calldata _addresses, uint256[] calldata _amounts) external payable;
+}


### PR DESCRIPTION
I'd like to use GasliteDrop in one of my contracts - specifically as more of an interface - but the version is fixed.

It'd be great to use `^0.8.19`, or we can create a `IGasliteDrop` interface marked as `^0.8.0`