### PR TITLE
fix: foundry deploy and verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Compiler outputs
+/cache
+/zkout

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,8 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.19"
+
+[profile.default.zksync]
+zksolc = "1.5.6"


### PR DESCRIPTION
Added the foundry.toml file to the repository to
specify using zksolc to `1.5.6`

This allowed me to deploy and verify the contract
without changes
as in the steps mentioned in the [Github Discussion post](https://github.com/zkSync-Community-Hub/zksync-developers/discussions/756)

Verified contract on Abstract testnet: <https://explorer.testnet.abs.xyz/address/0xD499fb7cD2d356cdAd3338B85262b26e784587ed#contract>